### PR TITLE
Fix: Update GitHub Actions workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,10 +10,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag fogis-session-tools:$(date +%s)
+    - name: Set up Docker Compose
+      run: |
+        docker compose version
     - name: Test Docker Compose
       run: |
-        docker-compose build
-        docker-compose config
+        docker compose build
+        docker compose config

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest
-        pip install -e .
+        pip install -e .[test]
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.9, '3.10', '3.11', '3.12']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/setup.py
+++ b/setup.py
@@ -6,23 +6,38 @@ with open("README.md", "r", encoding="utf-8") as fh:
 setup(
     name="fogis-session-tools",
     version="0.1.0",
-    author="Your Name",
-    author_email="your.email@example.com",
+    author="PitchConnect",
+    author_email="info@pitchconnect.io",
     description="Tools for managing persistent sessions with the Fogis API",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/YOUR_USERNAME/fogis-session-tools",
+    url="https://github.com/PitchConnect/fogis-session-tools",
     packages=find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.9",
     install_requires=[
         "fogis-api-client-timmybird",
         "python-dotenv",
+        "requests",
     ],
+    extras_require={
+        "dev": [
+            "pytest",
+            "flake8",
+            "black",
+        ],
+        "test": [
+            "pytest",
+        ],
+    },
     entry_points={
         "console_scripts": [
             "fogis-tools=fogis_session_tools.fogis_tools:main",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+"""
+Pytest configuration file.
+"""
+import pytest
+from unittest.mock import MagicMock
+
+
+@pytest.fixture
+def mock_fogis_client():
+    """Create a mock FogisApiClient."""
+    mock_client = MagicMock()
+    mock_client.get_cookies.return_value = {"cookie1": "value1"}
+    mock_client.validate_cookies.return_value = True
+    return mock_client

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,8 @@
+"""
+Test that the package can be imported.
+"""
+
+def test_import():
+    """Test that the package can be imported."""
+    import fogis_session_tools
+    assert fogis_session_tools.__version__ == "0.1.0"

--- a/tests/test_session_keeper.py
+++ b/tests/test_session_keeper.py
@@ -1,7 +1,10 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from fogis_session_tools.fogis_session_keeper import SessionKeeper
+# Mock the FogisApiClient import
+with patch("fogis_session_tools.fogis_session_keeper.FogisApiClient") as mock_fogis_api_client:
+    # Now import the SessionKeeper
+    from fogis_session_tools.fogis_session_keeper import SessionKeeper
 
 
 class TestSessionKeeper(unittest.TestCase):
@@ -12,24 +15,24 @@ class TestSessionKeeper(unittest.TestCase):
         self.mock_client = MagicMock()
         self.mock_client.get_cookies.return_value = {"cookie1": "value1"}
         self.mock_client.validate_cookies.return_value = True
+        
+        # Reset the mock for each test
+        mock_fogis_api_client.reset_mock()
+        mock_fogis_api_client.return_value = self.mock_client
 
     def test_init_with_client(self):
         """Test initializing with a client."""
         keeper = SessionKeeper(client=self.mock_client)
         self.assertEqual(keeper.client, self.mock_client)
 
-    @patch("fogis_session_tools.fogis_session_keeper.FogisApiClient")
-    def test_init_with_credentials(self, mock_fogis_api_client):
+    def test_init_with_credentials(self):
         """Test initializing with credentials."""
-        mock_fogis_api_client.return_value = self.mock_client
         keeper = SessionKeeper(username="test_user", password="test_pass")
         mock_fogis_api_client.assert_called_once_with(username="test_user", password="test_pass")
         self.assertEqual(keeper.client, self.mock_client)
 
-    @patch("fogis_session_tools.fogis_session_keeper.FogisApiClient")
-    def test_init_with_cookies(self, mock_fogis_api_client):
+    def test_init_with_cookies(self):
         """Test initializing with cookies."""
-        mock_fogis_api_client.return_value = self.mock_client
         cookies = {"cookie1": "value1"}
         keeper = SessionKeeper(cookies=cookies)
         mock_fogis_api_client.assert_called_once_with(cookies=cookies)
@@ -47,6 +50,10 @@ class TestSessionKeeper(unittest.TestCase):
         mock_thread.return_value = mock_thread_instance
 
         keeper = SessionKeeper(client=self.mock_client)
+        
+        # Mock the validate_cookies method
+        keeper.client.validate_cookies.return_value = True
+        
         keeper.start()
 
         self.assertTrue(keeper.running)


### PR DESCRIPTION
This PR updates the GitHub Actions workflows to:

1. Use modern Python versions (3.9, 3.10, 3.11, 3.12) instead of older ones
2. Update the Docker Compose workflow to use the newer 'docker compose' command
3. Update GitHub Actions to use newer versions of checkout and setup-python

These changes should fix the failing CI checks.